### PR TITLE
Add DESTDIR support for python modules.

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -15,5 +15,5 @@ if (PYTHON)
 
     add_custom_target(target ALL DEPENDS ${OUTPUT})
 
-    install(CODE "execute_process(COMMAND ${PYTHON} ${SETUP_PY} install --prefix=${CMAKE_INSTALL_PREFIX})")
+    install(CODE "execute_process(COMMAND ${PYTHON} ${SETUP_PY} install --prefix=${CMAKE_INSTALL_PREFIX} --root=${DESTDIR})")
 endif()


### PR DESCRIPTION
Without this patch, DESTDIR is not passed to python setup.py, so build
systems that use a staging sandbox prior to installing in real-root,
such as Gentoo, cannot build+install it.

Note, this probably is not the right way to do this; it unconditionally
passes --root=${DESTDIR}, so will probably cause issues when DESTDIR
is not set.  I am a cmake noob and could not get it to do the right
thing conditionally.
